### PR TITLE
Fixes #1

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ export const vLinkify = {
    bind: function (el, binding) {
 
       var urlPattern = /\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim;
-      var pseudoUrlPattern = /(^|[^\/])(www\.[\S]+(\b|$))/gim;
+      var pseudoUrlPattern = /\bwww\.[\S]+\.[\S]+/gim;
       var emailAddressPattern = /[\w.]+@[a-zA-Z_-]+?(?:\.[a-zA-Z]{2,6})+/gim;
 
       el.innerHTML = el.textContent.split(' ').map(text => {


### PR DESCRIPTION
I updated the regex for `pseudoUrlPattern` as it returned multiple matches due to the use of regex groups. This regex uses stricter checking that specifically looks for the format `www.` and `.<extension>`. This returns only 1 match per URL, compared to the previous 4. It also works for anything trailing the URL such as slashes, hashes and what not.

This fixes #1 