### PR TITLE
Fix build failure on Node 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple Vue directive to turn URL's and emails into clickable links",
   "main": "dist/index.js",
   "scripts": {
-    "build": "webpack --mode production"
+    "build": "node --openssl-legacy-provider ./node_modules/webpack/bin/webpack.js --mode production"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- set `NODE_OPTIONS` in npm build script to handle OpenSSL 3 requirement on newer Node versions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ae81708b4832c9e857ae398f74bd4