### PR TITLE
Add Vue 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-dist/
+dist

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 
 
 > A simple Vue directive to turn URL's and emails into clickable links.
+Supports Vue 2 and Vue 3.
 > NO dependencies!
 
 ## Installation
@@ -28,12 +29,23 @@ npm install v-linkify
 ```
 
 ## Install globally
-_main.js_
+_main.js (Vue 2)_
 ```js
 import Vue from 'vue';
 import vLinkify from 'v-linkify';
 
 Vue.use(vLinkify)
+```
+
+_main.js (Vue 3)_
+```js
+import { createApp } from 'vue';
+import App from './App.vue';
+import vLinkify from 'v-linkify';
+
+const app = createApp(App);
+app.use(vLinkify);
+app.mount('#app');
 ```
 
 ## Install locally

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,28 @@
 import findLinksAndReplace from "./utils/findLinksAndReplace.js";
 
+function applyDirective(el, binding, vnode) {
+  const text =
+    typeof vnode?.children === "string"
+      ? vnode.children
+      : vnode?.children?.[0]?.text || vnode?.children?.[0]?.children || "";
+
+  if (text) {
+    el.textContent = text;
+  }
+  findLinksAndReplace(el, binding?.value);
+}
+
 export const vLinkify = {
-  bind: function (el, binding) {
-    findLinksAndReplace(el, binding?.value);
-  },
-  componentUpdated: function(el, binding, vNode) {
-    const newEl = el;
-    newEl.textContent = vNode?.children[0]?.text || '';
-    findLinksAndReplace(newEl, binding?.value);
-  },
+  // Vue 2
+  bind: applyDirective,
+  componentUpdated: applyDirective,
+  // Vue 3
+  mounted: applyDirective,
+  updated: applyDirective,
 };
+
 export default {
-  install(Vue, options) {
-    Vue.directive("linkify", vLinkify);
+  install(app) {
+    app.directive("linkify", vLinkify);
   },
 };


### PR DESCRIPTION
## Summary
- extend directive hooks for Vue 2 and Vue 3 compatibility
- update plugin install function for Vue 3
- document Vue 3 usage
- clean up .gitignore

## Testing
- `NODE_OPTIONS=--openssl-legacy-provider npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684ae834ca40832c8e6ec5a732b1b23c