### PR TITLE
Add phone link support and rel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ![Git fork](https://img.shields.io/github/forks/maorbarel/v-linkify?style=social)
 
 
-> A simple Vue directive to turn URL's and emails into clickable links.
+> A simple Vue directive to turn URL's, emails and phone numbers into clickable links.
 > NO dependencies!
 
 ## Installation
@@ -52,7 +52,7 @@ export default {
 <template>
    <div v-linkify>
       v-linkify https://github.com/maorbarel/v-linkify
-      Vue directive to parse links (urls, emails, etc.)
+      Vue directive to parse links (urls, emails, phones, etc.)
       in text into clickable links
    </div>
 </template>
@@ -61,9 +61,9 @@ export default {
 ## Advanced Usage
 ```js
 <template>
-   <div v-linkify="{ className: 'myClassName', target: '_self' }">
+   <div v-linkify="{ className: 'myClassName', target: '_self', rel: 'nofollow' }">
       v-linkify https://github.com/maorbarel/v-linkify
-      Vue directive to parse links (urls, emails, etc.) 
+      Vue directive to parse links (urls, emails, phones, etc.)
       in text into clickable links
    </div>
 </template>
@@ -72,6 +72,7 @@ export default {
 ## Options
 - `className | String`
 - `target | String, _blank By default`
+- `rel | String, noopener noreferrer By default`
 
 ## Authors
 [Maor Barel](https://www.linkedin.com/in/maorbarel "Personal website")

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -2,8 +2,13 @@ export const REGEX_PATTERN = {
   URL: /\b(?:https?|ftp):\/\/[a-z0-9-+&@#\/%?=~_|!:,.;]*[a-z0-9-+&@#\/%=~_|]/gim,
   PSEUDO_URL: /\bwww\.[\S]+\.[\S]+/gim,
   EMAIL_ADDRESS: /[\w.]+@[a-zA-Z_-]+?(?:\.[a-zA-Z]{2,6})+/gim,
+  PHONE: /\b(?:\+?\d{1,4}[\s-]?)?(?:\(\d+\)[\s-]?)?[\d\s-]{5,}\d\b/gim,
 };
 
 export const LINK_TARGET = {
   DEFAULT: "_blank",
+};
+
+export const LINK_REL = {
+  DEFAULT: "noopener noreferrer",
 };

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,10 +1,11 @@
-import { LINK_TARGET, REGEX_PATTERN } from "./constants.js";
+import { LINK_TARGET, LINK_REL, REGEX_PATTERN } from "./constants.js";
 
 export function findMatchedText(text = "") {
   return [
     ...text.matchAll(REGEX_PATTERN.EMAIL_ADDRESS),
     ...text.matchAll(REGEX_PATTERN.URL),
     ...text.matchAll(REGEX_PATTERN.PSEUDO_URL),
+    ...text.matchAll(REGEX_PATTERN.PHONE),
   ].flat();
 }
 
@@ -12,9 +13,10 @@ export function createElementAttributesOptions(params) {
   if (_isObject(params)) {
     const elClass = _createDOMClass(params?.className);
     const elLinkTarget = _createLinkTarget(params?.target);
-    return `${elClass} ${elLinkTarget}`;
+    const elRel = _createRel(params?.rel);
+    return `${elClass} ${elLinkTarget} ${elRel}`;
   }
-  return _createLinkTarget();
+  return `${_createLinkTarget()} ${_createRel()}`;
 }
 
 export function formatText(baseText, matchedText, options) {
@@ -23,6 +25,9 @@ export function formatText(baseText, matchedText, options) {
   }
   if (matchedText.match(REGEX_PATTERN.URL) !== null || matchedText.match(REGEX_PATTERN.PSEUDO_URL) !== null) {
     baseText = _formatUrlText(baseText, matchedText, options);
+  }
+  if (matchedText.match(REGEX_PATTERN.PHONE) !== null) {
+    baseText = _formatPhoneText(baseText, matchedText, options);
   }
   return baseText
 }
@@ -39,6 +44,10 @@ function _createLinkTarget(target) {
   return `target="${target || LINK_TARGET.DEFAULT}"`;
 }
 
+function _createRel(rel) {
+  return `rel="${rel || LINK_REL.DEFAULT}"`;
+}
+
 function _formatEmailText(baseText, matchedText, options) {
   return baseText.replace(matchedText, `<a ${options} href="mailto:${matchedText}">${matchedText}</a>`)
 }
@@ -46,4 +55,9 @@ function _formatEmailText(baseText, matchedText, options) {
 function _formatUrlText(baseText, matchedText, options) {
   const prefix = matchedText.toLowerCase().indexOf('http') === -1 && matchedText.toLowerCase().indexOf('ftp') === -1 ? '//' : '';
   return baseText.replace(matchedText, `<a ${options} href="${prefix + matchedText.trim()}">${matchedText}</a>`);
+}
+
+function _formatPhoneText(baseText, matchedText, options) {
+  const digits = matchedText.replace(/[^+\d]/g, '');
+  return baseText.replace(matchedText, `<a ${options} href="tel:${digits}">${matchedText}</a>`);
 }


### PR DESCRIPTION
## Summary
- support telephone link detection
- allow setting rel attribute on generated links
- document new features

## Testing
- `npm run build` *(fails: Error: ERR_OSSL_EVP_UNSUPPORTED)*

------
https://chatgpt.com/codex/tasks/task_e_684ae82897d8832c9989987d8a1e4f44